### PR TITLE
feat: チャット入力の空文字入力防止機能を追加

### DIFF
--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -20,8 +20,18 @@ onMounted(() => {
 
 // #region browser event handler
 // 投稿メッセージをサーバに送信する
+// より厳密なバリデーション例
 const onPublish = () =>  {
-  ChatService.publish(chatContent.value, userName.value)
+  const trimmedContent = chatContent.value.trim()
+  
+  // 空文字列、スペースのみ、改行のみをチェック
+  if (!trimmedContent || trimmedContent.length === 0) {
+    // オプション: ユーザーにアラートを表示
+    // alert("メッセージを入力してください")
+    return
+  }
+  
+  ChatService.publish(trimmedContent, userName.value)
   chatContent.value = ""
 }
 
@@ -32,7 +42,17 @@ const onExit = () => {
 
 // メモを画面上に表示する
 const onMemo = () => {
-  const memoMessage = `${userName.value}さんのメモ:${chatContent.value}`
+  // 入力内容をトリム（前後の空白を除去）
+  const trimmedContent = chatContent.value.trim()
+  
+  // 空文字列、スペースのみ、改行のみをチェック
+  if (!trimmedContent || trimmedContent.length === 0) {
+    // オプション: ユーザーにアラートを表示
+    // alert("メモ内容を入力してください")
+    return
+  }
+  
+  const memoMessage = `${userName.value}さんのメモ:${trimmedContent}`
   chatList.push(memoMessage)
   chatContent.value = ""
 }


### PR DESCRIPTION
## 変更内容
- チャット投稿機能に入力バリデーションを追加（onPublish）
- メモ機能に入力バリデーションを追加（onMemo）
- trim()メソッドで前後の空白を除去
- 空文字列、スペースのみ、改行のみの投稿を防止

## 修正したファイル
- `src/components/Chat.vue`

## 実装詳細
- `chatContent.value.trim()` でバリデーション
- 無効な入力の場合は早期リターンで処理を停止
- 有効な入力のみチャット/メモリストに追加

## 動作確認済み
- [x] 空文字列での投稿が防止される
- [x] スペースのみでの投稿が防止される
- [x] 改行のみでの投稿が防止される
- [x] 正常な文字列は投稿できる
- [x] メモ機能も同様にバリデーションが効く