### PR TITLE
feat: チャットメッセージの改行表示

### DIFF
--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -91,7 +91,15 @@ const registerSocketEvent = () => {
       </div>
       <div class="mt-5" v-if="chatList.length !== 0">
         <ul>
-          <li class="item mt-4" v-for="(chat, i) in reversedChatList" :key="i">{{ chat }}</li>
+          <li class="chat-item" v-for="(chatString, i) in reversedChatList" :key="i">
+            <template v-if="chatString.includes(':')">
+              <span class="chat-publisher">{{ chatString.substring(0, chatString.indexOf(':') + 1) }}</span>
+              <span class="chat-content chat-message-display">{{ chatString.substring(chatString.indexOf(':') + 1) }}</span>
+            </template>
+            <template v-else>
+              <span class="chat-content chat-message-display">{{ chatString }}</span>
+            </template>
+          </li>
         </ul>
       </div>
     </div>
@@ -112,9 +120,32 @@ const registerSocketEvent = () => {
   margin-top: 8px;
 }
 
-.item {
+/* === 追加 === */
+.chat-item {
+  display: flex; /* Flexboxコンテナにする */
+  align-items: flex-start; /* アイテムを上端に揃える */
+  margin-top: 16px; /* item mt-4 の代わりに直接マージンを設定 */
+}
+
+.chat-publisher {
+  flex-shrink: 0; /* 投稿者名が縮まないようにする */
+  margin-right: 5px; /* 投稿者名とメッセージの間に少しスペース */
   display: block;
 }
+
+.chat-content {
+  flex-grow: 1; /* 残りのスペースを全て占有させる */
+  min-width: 0; /* 内容がはみ出さないようにする*/
+  display: block;
+}
+
+.chat-message-display { /*改行*/
+  white-space: pre-wrap;
+  word-wrap: break-word; 
+  overflow-wrap: break-word; 
+}
+/*===ここまで追加===*/
+
 
 .util-ml-8px {
   margin-left: 8px;


### PR DESCRIPTION
変更内容
Chat.vueのtempleteとcssを修正して<li> 要素をFlexboxでレイアウトし、メッセージ本文に white-space: pre-wrap; を適用するようにした。
テスト
メッセージを入力する際にenterで改行して正しく表示されるか(改行＋メッセージ同士のインデントが揃っているかどうか）